### PR TITLE
Feature/papertrail remote

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -47,11 +47,10 @@ suites:
                 \*:
                   SendEnv: "LANG LC_*"
                   ForwardAgent: "yes"
-                  HostkeyAlgorithms: "+ssh-ed25519,ssh-rsa,ssh-dss,ecdsa-sha2-nistp256"
                   UserKnownHostsFile: "/dev/null"
                   StrictHostKeyChecking: "no"
               keys:
-                id_rsa-test:
+                id_rsa:
                   owner: root
                   ssh_key_bucket: "<%= ENV['SSH_KEY_BUCKET'] %>"
                   ssh_key_path: "<%= ENV.key?('ROOT_SSH_KEY_PATH') ? ENV['ROOT_SSH_KEY_PATH'] : 'ssh-keys/root' %>"
@@ -79,11 +78,11 @@ suites:
         papertrail:
           enabled: true
           remote_host: '@@log.example.com:11111'
-          files:
-            - /some/file/without-tags
-            - /some/file/with-tag
-              tag: test
-hi  - name: ruby
+          remote_syslog2:
+            files:
+              - /some/file/without-tags:
+              - /some/file/with-tag: 'test'
+  - name: ruby
     data_bags_path: "../../data_bags"
     run_list:
       - recipe[system_core::default]
@@ -93,13 +92,9 @@ hi  - name: ruby
     run_list:
       - recipe[system_core::default]
       - recipe[system_core::repos]
-      - recipe[system_core::awscli]
-      - recipe[system_core::bash]
-      - recipe[system_core::postfix]
-      - recipe[system_core::ntp]
-      - recipe[system_core::selinux]
-      - recipe[system_core::ssh]
-      - recipe[system_core::logrotate]
+    verifier:
+      attributes:
+        default_domain: linux.alt.org
     attributes:
       system_core:
         aws:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -69,6 +69,7 @@ suites:
       - recipe[system_core::rsyslog]
       - recipe[system_core::logrotate]
       - recipe[system_core::papertrail]
+      - recipe[system_core::papertrail_remote]
       - recipe[logrotate::default]
     verifier:
       attributes:
@@ -78,7 +79,11 @@ suites:
         papertrail:
           enabled: true
           remote_host: '@@log.example.com:11111'
-  - name: ruby
+          files:
+            - /some/file/without-tags
+            - /some/file/with-tag
+              tag: test
+hi  - name: ruby
     data_bags_path: "../../data_bags"
     run_list:
       - recipe[system_core::default]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,24 +7,30 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: <%= ENV.has_key?('CHEF_VERSION') ? ENV['CHEF_VERSION'] : true %>
+  require_chef_omnibus: "<%= ENV.has_key?('CHEF_VERSION') ? ENV['CHEF_VERSION'] : true %>"
 
 verifier:
   name: inspec
 
 platforms:
+  - name: ubuntu-16.04
+  - name: ubuntu-18.04
   - name: centos-6.9
-  - name: centos-7.3
+  - name: centos-7.5
   - name: oracle-6.9
-  - name: oracle-7.3
+  - name: oracle-7.5
     driver_config:
-      box: bento/oracle-7.3
+      box: bento/oracle-7.5
 
 suites:
   - name: base
     data_bags_path: "../../data_bags"
     run_list:
       - recipe[system_core::default]
+      # This seems to be automatically installed by RHEL / CentOS / Oracle,
+      # but not by Debian, which causes the Debian tests to fail because they
+      # are looking for auditd
+      - recipe[system_core::auditd]
       - recipe[system_core::repos]
       - recipe[system_core::awscli]
       - recipe[system_core::bash]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - 'Vagrantfile'
+    - vendor/**/*
   DisplayCopNames: true
 
 AlignParameters:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+---
+sudo: false
+language: ruby
+bundler_args: "--without development"
+dist: trusty
+cache: bundler
+
+rvm: 2.4.1
+
+before_install:
+  - gem update --system # see https://github.com/bundler/bundler/issues/5357
+
+matrix:
+  include:
+    - env: UNIT_AND_LINT=1
+      script:
+        - bundle exec rake lint spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # system_core Cookbook Change Log
 
+## 2.0.0
+- Add support for Ubuntu 16 OS
+- Add papertrail_remote recipe and corresponding unit/integration tests
+- Add audit recipe for configuration of Auditd within guidelines from [Linux Baseline](https://github.com/dev-sec/linux-baseline) security
+
 ## 1.1.0
 - Add basic configuration of auditd to match dev sec standards; current configuration does not use a template and thus is fixed
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'chef', '~> 13.0'
 gem 'inspec', '~> 1.51.0'
 
 group :test do
-  gem 'bundler', '~> 1.15.0'
+  gem 'bundler', '>= 1.15.0'
   gem 'minitest', '~> 5.11.0'
   gem 'rake', '~> 12.3.0'
   gem 'simplecov', '~> 0.15.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,41 +1,52 @@
 source 'https://rubygems.org'
 
-gem 'inspec', path: '../../.'
+gem 'berkshelf', '~> 6.1'
+gem 'chef', '~> 13.0'
+gem 'inspec', '~> 1.51.0'
 
 group :test do
-  gem 'bundler', '~> 1.5'
-  gem 'foodcritic', '~> 5.0'
-  gem 'minitest', '~> 5.5'
-  gem 'overcommit'
-  gem 'rake', '~> 10'
-  gem 'rubocop', '~> 0.49.0'
-  gem 'simplecov', '~> 0.10'
-  gem 'tomlrb'
+  gem 'bundler', '~> 1.16.0'
+  gem 'minitest', '~> 5.11.0'
+  gem 'rake', '~> 12.3.0'
+  gem 'simplecov', '~> 0.15.0'
+end
+
+group :rake do
+  gem 'rake', '~> 12.3.0' # rubocop:disable Bundler/DuplicatedGem
+  gem 'tomlrb', '~> 1.2.0'
+end
+
+group :lint do
+  gem 'foodcritic', '~> 12.3.0'
+  gem 'overcommit', '~> 0.43.0'
+  gem 'rubocop', '~> 0.52.0'
 end
 
 group :unit do
-  gem 'berkshelf',  '~> 4.0'
-  gem 'chefspec',   '~> 4.4'
+  gem 'chefspec', '~> 7.1.0'
 end
 
 group :kitchen_common do
-  gem 'serverspec'
-  gem 'test-kitchen', '~> 1.4'
+  gem 'test-kitchen', '~> 1.20.0'
 end
 
 group :kitchen_vagrant do
-  gem 'kitchen-docker'
-  gem 'kitchen-dokken'
-  gem 'kitchen-vagrant', '~> 0.19'
+  gem 'kitchen-docker', '~> 2.6.0'
+  gem 'kitchen-dokken', '~> 2.6.0'
+  gem 'kitchen-vagrant', '~> 1.3.0'
 end
 
 group :development do
-  gem 'growl'
-  gem 'guard', '~> 2.4'
-  gem 'guard-foodcritic'
-  gem 'guard-kitchen'
-  gem 'guard-rspec'
-  gem 'guard-rubocop'
-  gem 'rb-fsevent'
-  gem 'ruby_gntp'
+  gem 'growl', '~> 1.0.0'
+  gem 'guard', '~> 2.14.0'
+  gem 'guard-foodcritic', '~> 3.0.0'
+  gem 'guard-kitchen', '~> 0.0.0'
+  gem 'guard-rspec', '~> 4.7.0'
+  gem 'guard-rubocop', '~> 1.3.0'
+  gem 'rb-fsevent', '~> 0.10.0'
+  gem 'ruby_gntp', '~> 0.3.0'
+end
+
+group :tools do
+  gem 'github_changelog_generator', '~> 1.14'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'chef', '~> 13.0'
 gem 'inspec', '~> 1.51.0'
 
 group :test do
-  gem 'bundler', '~> 1.16.0'
+  gem 'bundler', '~> 1.15.0'
   gem 'minitest', '~> 5.11.0'
   gem 'rake', '~> 12.3.0'
   gem 'simplecov', '~> 0.15.0'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 system_core Cookbook
 =======================
-Performs general system configuration that is core to all servers. Also provides some attributes that are leveraged by other cookbooks, although attempts are
-made to limit such dependencies. Examples of 'core' configuration including SSH, the AWS CLI, bash customizations, logrotate, NTP, rsyslog, selinux, and mail
+Performs general system configuration that is core to all servers. Also provides some attributes that are
+leveraged by other cookbooks, although attempts aremade to limit such dependencies. Examples of 'core'
+configuration including SSH, the AWS CLI, bash customizations, logrotate, NTP, rsyslog, selinux, and mail
 server configuration.
 
-*Note* that this cookbook depends and a number of other cookbooks to perform the actual work, this is essentially just a wrapper around those cookbooks.
+*Note* that this cookbook depends and a number of other cookbooks to perform the actual work, this is
+essentially just a wrapper around those cookbooks.
 
 Requirements
 ------------
@@ -42,170 +44,8 @@ Requirements
 
 Attributes
 ----------
-#### system_core::awscli
-<table>
-  <tr>
-    <th>Key</th>
-    <th>Type</th>
-    <th>Description</th>
-    <th>Default</th>
-  </tr>
-  <tr>
-    <td><tt>['system_core']['awscli']['version']</tt></td>
-    <td>String</td>
-    <td>The version of the AWS CLI to be downloaded from AWS and installed</td>
-    <td><tt>1.4.4</tt></td>
-  </tr>
-  <tr>
-    <td><tt>['system_core']['awscli']['packages']</tt></td>
-    <td>Array</td>
-    <td>Any additional packages required for, or helping when, using the AWS CLI</td>
-    <td><tt>%w[jq wget curl unzip]</tt></td>
-  </tr>
-  <tr>
-    <td><tt>['system_core']['awscli']['profiles']</tt></td>
-    <td>Attributes hash</td>
-    <td>This is hash of attributes with the first element being the AWS profile name. Under the profile name, the following attributes can be set:<br>
-      <table>
-        <tr>
-          <td><tt>['output_format']</tt></td>
-          <td>Default format used when content is output, see the AWS CLI documentation for allowed values.</td>
-        </tr>
-        <tr>
-          <td><tt>['default_region']</tt></td>
-          <td>The default region used for this profile by the CLI unless overridden on the command line.</td>
-        </tr>
-        <tr>
-          <td><tt>['access_key']</tt></td>
-          <td>The access key used when using the CLI; only necessary if running on a system that does not have an IAM profile (which makes it required for any non-EC2 systems.) Also requires that the <strong>secret_key</strong> is specified.</td>
-        </tr>
-        <tr>
-          <td><tt>['secret_key']</tt></td>
-          <td>The secret access key used when using the CLI; only necessary if running on a system that does not have an IAM profile (which makes it required for any non-EC2 systems.) Also requires that the <strong>access_key</strong> is specified.</td>
-        </tr>
-      </table>
-    </td>
-    <td><tt>nil</tt></td>
-  </tr>
-</table>
-
-#### system_core::bash
-There currently are no custom attributes.
-
-#### system_core::default
-There currently are no custom attributes.
-
-#### system_core::hostname
-There currently are no custom attributes.
-
-#### system_core::logrotate
-<table>
-  <tr>
-    <th>Key</th>
-    <th>Type</th>
-    <th>Description</th>
-    <th>Default</th>
-  </tr>
-  <tr>
-    <td><tt>['system_core']['awscli']['version']</tt></td>
-    <td>String</td>
-    <td>The version of the AWS CLI to be downloaded from AWS and installed</td>
-    <td><tt>1.4.4</tt></td>
-  </tr>
-  <tr>
-    <td><tt>['system_core']['awscli']['packages']</tt></td>
-    <td>Array</td>
-    <td>Any additional packages required for, or helping when, using the AWS CLI</td>
-    <td><tt>%w[jq wget curl unzip]</tt></td>
-  </tr>
-</table>
-
-#### system_core::ntp
-There currently are no custom attributes.
-
-#### system_core::papertrail
-There currently are no custom attributes.
-
-#### system_core::postfix
-There currently are no custom attributes.
-
-#### system_core::rbenv
-<table>
-  <tr>
-    <th>Key</th>
-    <th>Type</th>
-    <th>Description</th>
-    <th>Default</th>
-  </tr>
-  <tr>
-    <td><tt>['system_core']['ruby']['global']</tt></td>
-    <td>String</td>
-    <td>The version of Ruby to be installed by rbenv</td>
-    <td><tt>2.2.2</tt></td>
-  </tr>
-  <tr>
-    <td><tt>['system_core']['ruby']['packages']</tt></td>
-    <td>Array</td>
-    <td>An array of strings indicating the Ruby GEMs to be installed when Ruby is installed</td>
-    <td><tt>%w[bundler backup]</tt></td>
-  </tr>
-</table>
-
-#### system_core::repos
-<table>
-  <tr>
-    <th>Key</th>
-    <th>Type</th>
-    <th>Description</th>
-    <th>Default</th>
-  </tr>
-  <tr>
-    <td><tt>['system_core']['system']['packages']</tt></td>
-    <td>Array</td>
-    <td>An array of String values where each array element is the name of a package to be installed</td>
-    <td><tt>%w( rsyslog gnutls rsyslog-gnutls perl-YAML-LibYAML acpid python-cheetah python-configobj vim-enhanced screen python-pip git htop
-                bash-completion gcc ruby-devel zlib-devel ipa-client xfsprogs xfsprogs-devel tmux xfsdump mutt cloud-init )</tt></td>
-  </tr>
-</table>
-
-#### system_core::rsyslog
-There currently are no custom attributes.
-
-#### system_core::selinux
-There currently are no custom attributes.
-
-#### system_core::ssh
-<table>
-  <tr>
-    <th>Key</th>
-    <th>Type</th>
-    <th>Description</th>
-    <th>Default</th>
-  </tr>
-  <tr>
-    <td><tt>['environment']</tt></td>
-    <td>String</td>
-    <td>The name of the environment in which the recipe is running; typically this corresponds to the Chef environment</td>
-    <td><tt>nil</tt></td>
-  </tr>
-</table>
-
-
-#### system_core::user_ssh
-<table>
-  <tr>
-    <th>Key</th>
-    <th>Type</th>
-    <th>Description</th>
-    <th>Default</th>
-  </tr>
-  <tr>
-    <td><tt>['system_core']['ssh']['user_config']</tt></td>
-    <td>String</td>
-    <td>The group created and which is used to run any web server applications</td>
-    <td><tt>web</tt></td>
-  </tr>
-</table>
+Attributes are available from the various files in the _attributes/_ path, please review the files there
+for all details about attributes.
 
 Usage
 -----

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,86 @@
+# encoding: utf-8
+
+require 'foodcritic'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+require 'base64'
+require 'chef/cookbook/metadata'
+
+# General tasks
+
+# Rubocop before rspec so we don't lint vendored cookbooks
+desc 'Run all tests except Kitchen (default task)'
+task default: [:lint, :spec]
+
+# Lint the cookbook
+desc 'Run all linters: rubocop and foodcritic'
+task lint: [:rubocop, :foodcritic]
+
+# Run the whole shebang
+desc 'Run all tests'
+task test: [:lint, :kitchen, :spec]
+
+# RSpec
+desc 'Run chefspec tests'
+task :spec do
+  puts 'Running Chefspec tests'
+  RSpec::Core::RakeTask.new(:spec)
+end
+
+# Foodcritic
+desc 'Run foodcritic lint checks'
+task :foodcritic do
+  puts 'Running Foodcritic tests...'
+  FoodCritic::Rake::LintTask.new do |t|
+    t.options = { fail_tags: ['any'] }
+    puts 'done.'
+  end
+end
+
+# Rubocop
+desc 'Run Rubocop lint checks'
+task :rubocop do
+  RuboCop::RakeTask.new
+end
+
+# Automatically generate a changelog for this project. Only loaded if
+# the necessary gem is installed.
+begin
+  # read version from metadata
+  metadata = Chef::Cookbook::Metadata.new
+  metadata.instance_eval(File.read('metadata.rb'))
+
+  # build changelog
+  require 'github_changelog_generator/task'
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    config.future_release = "v#{metadata.version}"
+    config.user = 'dev-sec'
+    config.project = 'chef-os-hardening'
+  end
+rescue LoadError
+  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
+end
+
+desc 'Run kitchen integration tests'
+task :kitchen do
+  concurrency = ENV['CONCURRENCY'] || 1
+  instance = ENV['INSTANCE'] || ''
+  args = ENV['CI'] ? '--destroy=always' : ''
+  sh('sh', '-c', "bundle exec kitchen test -c #{concurrency} #{args} #{instance}")
+end
+
+desc 'Prepare CI environment for DigitalOcean usage'
+task :prepare_do_env do
+  SSH_KEY_FILE = '~/.ssh/ci_id_rsa'.freeze
+  ENV_VAR_NAME = 'CI_SSH_KEY'.freeze
+
+  ['DIGITALOCEAN_ACCESS_TOKEN', 'DIGITALOCEAN_SSH_KEY_IDS', ENV_VAR_NAME].each do |var|
+    raise "Environment variable #{var} should be set" unless ENV[var]
+  end
+
+  ssh_file = File.expand_path(SSH_KEY_FILE)
+  dir = File.dirname(ssh_file)
+  Dir.mkdir(dir, 0o700) unless Dir.exist?(dir)
+  File.open(ssh_file, 'w') { |f| f.puts Base64.decode64(ENV[ENV_VAR_NAME]) }
+  File.chmod(0o600, ssh_file)
+end

--- a/attributes/aws.rb
+++ b/attributes/aws.rb
@@ -19,7 +19,14 @@
 
 # ~ awscli ~ #
 node.default['system_core']['awscli']['version'] = '1.4.4'
-node.default['system_core']['awscli']['packages'] = %w[jq wget curl unzip]
+node.default['system_core']['awscli']['packages'] = case node['platform_family']
+                                                    when 'rhel'
+                                                      %w[jq wget curl unzip]
+                                                    when 'debian'
+                                                      # Require Markdown on Ubuntu, otherwise we get
+                                                      # cheetah 2.4.4 requires Markdown>=2.0.1, which is not installed.
+                                                      %w[jq wget curl unzip python-pip python-markdown python3-pip python3-markdown]
+                                                    end
 
 # Defines the attribute with no value so that we can use a shorter 'node['system_core']['aws'].attribute?('profiles')' test
 node.default['system_core']['aws']['profiles'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,11 +22,20 @@
 
 # ~ system packages ~ #
 # TODO: This should be determined by the platform_family and platform_version
-node.default['system_core']['system']['packages'] = %w[rsyslog gnutls rsyslog-gnutls perl-YAML-LibYAML acpid
-                                                       python-cheetah python-configobj vim-enhanced screen
-                                                       python-pip git htop bash-completion gcc ruby-devel
-                                                       zlib-devel ipa-client xfsprogs xfsprogs-devel
-                                                       tmux xfsdump mutt cloud-init sysstat]
+node.default['system_core']['system']['packages'] = case node['platform_family']
+                                                    when 'rhel'
+                                                      %w[rsyslog gnutls rsyslog-gnutls perl-YAML-LibYAML acpid
+                                                         python-cheetah python-configobj vim-enhanced screen
+                                                         python-pip git htop bash-completion gcc ruby-devel
+                                                         zlib-devel ipa-client xfsprogs xfsprogs-devel
+                                                         tmux xfsdump mutt cloud-init sysstat]
+                                                    when 'debian'
+                                                      %w[rsyslog gnutls-bin libgnutls30 rsyslog-gnutls libyaml-perl acpid
+                                                         python-cheetah python-configobj vim screen
+                                                         python-pip git htop bash-completion gcc ruby-dev
+                                                         zlib1g-dev freeipa-client xfsprogs xfslibs-dev
+                                                         tmux xfsdump mutt cloud-init sysstat]
+                                                    end
 
 # ~ chef-client syslog ~ #
 node.override['chef_client']['log']['syslog_facility'] = '::Syslog::LOG_DAEMON'

--- a/attributes/logging.rb
+++ b/attributes/logging.rb
@@ -25,8 +25,10 @@ node.default['system_core']['papertrail']['enabled'] = false
 # If Papertrail is enabled, this attribute needs set with the full name, including the leading '@' (for UDP) or
 # '@@' (for TCP) prefixes.
 # node.default['system_core']['papertrail']['remote_host'] = '@@log1.papertrailapp.com:12345'
+node.default['system_core']['papertrail']['remote_syslog2']['source_url_prefix'] = 'https://github.com/papertrail/remote_syslog2/releases/download'
+node.default['system_core']['papertrail']['remote_syslog2']['version'] = '0.20'
+node.default['system_core']['papertrail']['remote_syslog2']['service_name'] = 'remote_syslog'
 
-node.default['system_core']['papertrail']['remote_syslog2']['source_url'] = 'https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog2-0.20-1.x86_64.rpm'
 node.default['system_core']['papertrail']['remote_syslog2']['config']['file_name'] = '/etc/log_files.yaml'
 node.default['system_core']['papertrail']['remote_syslog2']['config']['template_file'] = '/etc/log_files.yaml'
 node.default['system_core']['papertrail']['remote_syslog2']['config']['template_cookbook'] = 'system_core'

--- a/attributes/logging.rb
+++ b/attributes/logging.rb
@@ -25,3 +25,14 @@ node.default['system_core']['papertrail']['enabled'] = false
 # If Papertrail is enabled, this attribute needs set with the full name, including the leading '@' (for UDP) or
 # '@@' (for TCP) prefixes.
 # node.default['system_core']['papertrail']['remote_host'] = '@@log1.papertrailapp.com:12345'
+
+node.default['system_core']['papertrail']['remote_syslog2']['source_url'] = 'https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog2-0.20-1.x86_64.rpm'
+node.default['system_core']['papertrail']['remote_syslog2']['config']['file_name'] = '/etc/log_files.yaml'
+node.default['system_core']['papertrail']['remote_syslog2']['config']['template_file'] = '/etc/log_files.yaml'
+node.default['system_core']['papertrail']['remote_syslog2']['config']['template_cookbook'] = 'system_core'
+node.default['system_core']['papertrail']['remote_syslog2']['config']['template_file'] = 'log_files.yaml.erb'
+
+node.default['system_core']['papertrail']['remote_syslog2']['protocol'] = 'tls'
+node.default['system_core']['papertrail']['remote_syslog2']['hostname'] = nil
+node.default['system_core']['papertrail']['remote_syslog2']['files'] = nil
+node.default['system_core']['papertrail']['remote_syslog2']['exclude_patterns'] = nil

--- a/attributes/openssh.rb
+++ b/attributes/openssh.rb
@@ -101,13 +101,8 @@ node.override['openssh']['server']['use_p_a_m']                         = 'yes'
 node.override['openssh']['server']['accept_env']                        = accept_env
 node.override['openssh']['server']['x11_forwarding']                    = 'no'
 
-unless ciphers.nil?
-  node.override['openssh']['server']['ciphers']                           = ciphers.join(',')
-end
-
-unless macs.nil?
-  node.override['openssh']['server']['mACs']                              = macs.join(',')
-end
+node.override['openssh']['server']['ciphers'] = ciphers.join(',') unless ciphers.nil?
+node.override['openssh']['server']['mACs']    = macs.join(',') unless macs.nil?
 
 if File.exist?('/usr/bin/sss_ssh_authorizedkeys') && File.exist?('/etc/ipa/ca.crt')
   # Override the default SSH settings - these are required in order to enable use of SSH keys stored in IPA

--- a/attributes/ssh.rb
+++ b/attributes/ssh.rb
@@ -31,7 +31,7 @@ node.override['ssh_known_hosts']['cacher']['data_bag_item'] = 'known_hosts'
 node.default['system_core']['ssh']['user_config']['root']['config']['hosts']['*'].tap do |config|
   config['SendEnv'] = 'LANG LC_*'
   config['ForwardAgent'] = 'yes'
-  config['HostkeyAlgorithms'] = '+ssh-ed25519,ssh-rsa,ssh-dss,ecdsa-sha2-nistp256'
+  config['HostkeyAlgorithms'] = '+ssh-ed25519,ssh-rsa,ssh-dss,ecdsa-sha2-nistp256' if node['platform_family'] == 'rhel' && node['platform_version'] =~ /^7/
   config['UserKnownHostsFile'] = '/dev/null'
   config['StrictHostKeyChecking'] = 'no'
 end

--- a/files/centos-6/auditd.conf
+++ b/files/centos-6/auditd.conf
@@ -1,0 +1,29 @@
+#
+# This file controls the configuration of the audit daemon
+#
+
+log_file = /var/log/audit/audit.log
+log_group = root
+log_format = RAW
+flush = INCREMENTAL_ASYNC
+freq = 50
+max_log_file = 8
+num_logs = 5
+priority_boost = 4
+disp_qos = lossy
+dispatcher = /sbin/audispd
+name_format = NONE
+max_log_file_action = keep_logs
+space_left = 75
+space_left_action = SYSLOG
+action_mail_acct = root
+admin_space_left = 50
+admin_space_left_action = SUSPEND
+disk_full_action = SUSPEND
+disk_error_action = SUSPEND
+use_libwrap = yes
+tcp_listen_queue = 5
+tcp_max_per_addr = 1
+tcp_client_max_idle = 0
+enable_krb5 = no
+krb5_principal = auditd

--- a/files/default/install-aws-cli.sh
+++ b/files/default/install-aws-cli.sh
@@ -8,10 +8,15 @@
 # https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
 # InsecurePlatformWarning
 
-if [ ! -e get-pip.py ] ; then
+if [ ! -e ./get-pip.py ] ; then
   # Only download if it hasn't already been downloaded
   curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
-  python get-pip.py
+  python ./get-pip.py
 fi
 
+# Fix for Ubuntu which puts pip into /usr/local/bin but which doesn't have /usr/local/bin
+# in the path by default (at least under Test Kitchen)
+if ! env | grep ^PATH | grep '/usr/local/bin' > /dev/null ; then
+  export PATH=$PATH:/usr/local/bin
+fi
 pip install awscli

--- a/files/oracle-6/auditd.conf
+++ b/files/oracle-6/auditd.conf
@@ -1,0 +1,29 @@
+#
+# This file controls the configuration of the audit daemon
+#
+
+log_file = /var/log/audit/audit.log
+log_group = root
+log_format = RAW
+flush = INCREMENTAL_ASYNC
+freq = 50
+max_log_file = 8
+num_logs = 5
+priority_boost = 4
+disp_qos = lossy
+dispatcher = /sbin/audispd
+name_format = NONE
+max_log_file_action = keep_logs
+space_left = 75
+space_left_action = SYSLOG
+action_mail_acct = root
+admin_space_left = 50
+admin_space_left_action = SUSPEND
+disk_full_action = SUSPEND
+disk_error_action = SUSPEND
+use_libwrap = yes
+tcp_listen_queue = 5
+tcp_max_per_addr = 1
+tcp_client_max_idle = 0
+enable_krb5 = no
+krb5_principal = auditd

--- a/files/redhat-6/auditd.conf
+++ b/files/redhat-6/auditd.conf
@@ -1,0 +1,29 @@
+#
+# This file controls the configuration of the audit daemon
+#
+
+log_file = /var/log/audit/audit.log
+log_group = root
+log_format = RAW
+flush = INCREMENTAL_ASYNC
+freq = 50
+max_log_file = 8
+num_logs = 5
+priority_boost = 4
+disp_qos = lossy
+dispatcher = /sbin/audispd
+name_format = NONE
+max_log_file_action = keep_logs
+space_left = 75
+space_left_action = SYSLOG
+action_mail_acct = root
+admin_space_left = 50
+admin_space_left_action = SUSPEND
+disk_full_action = SUSPEND
+disk_error_action = SUSPEND
+use_libwrap = yes
+tcp_listen_queue = 5
+tcp_max_per_addr = 1
+tcp_client_max_idle = 0
+enable_krb5 = no
+krb5_principal = auditd

--- a/files/ubuntu-16/auditd.conf
+++ b/files/ubuntu-16/auditd.conf
@@ -1,0 +1,29 @@
+#
+# This file controls the configuration of the audit daemon
+#
+
+log_file = /var/log/audit/audit.log
+log_group = root
+log_format = RAW
+flush = incremental
+freq = 50
+max_log_file = 8
+num_logs = 5
+priority_boost = 4
+disp_qos = lossy
+dispatcher = /sbin/audispd
+name_format = NONE
+max_log_file_action = keep_logs
+space_left = 75
+space_left_action = SYSLOG
+action_mail_acct = root
+admin_space_left = 50
+admin_space_left_action = SUSPEND
+disk_full_action = SUSPEND
+disk_error_action = SUSPEND
+use_libwrap = yes
+tcp_listen_queue = 5
+tcp_max_per_addr = 1
+tcp_client_max_idle = 0
+enable_krb5 = no
+krb5_principal = auditd

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,14 +6,14 @@ issues_url       'https://github.com/eyespies/system_core/issues'
 license          'Apache-2.0'
 description      'Core operating system configuration for Enterprise Linux'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.0'
+version          '2.0.0'
 chef_version     '>= 12'
 
+depends 'apt', '~> 6.0'
 # This is the 3ofcoins version and is the one from which all others are forked. Tried using the 'hostnames' version
 # from nathantsoi, however it does not properly support Oracle Linux. It also generates Chef warnings and although a
 # PR was submitted in January 2017 to eliminate the warnings, as of August 2017 the maintainer has not merged the PR.
 # So it seems the nathantsoi version is no longer maintained.
-depends 'apt', '~> 6.0'
 depends 'hostname', '~> 0.4.0'
 depends 'iptables', '~> 4.2.0'
 depends 'logrotate', '~> 2.2.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,6 +13,7 @@ chef_version     '>= 12'
 # from nathantsoi, however it does not properly support Oracle Linux. It also generates Chef warnings and although a
 # PR was submitted in January 2017 to eliminate the warnings, as of August 2017 the maintainer has not merged the PR.
 # So it seems the nathantsoi version is no longer maintained.
+depends 'apt', '~> 6.0'
 depends 'hostname', '~> 0.4.0'
 depends 'iptables', '~> 4.2.0'
 depends 'logrotate', '~> 2.2.0'
@@ -29,6 +30,7 @@ depends 'sudo', '~> 3.5.0'
 depends 'yum', '~> 5.0.0'
 depends 'yum-epel', '~> 2.1.0'
 
+supports 'ubuntu', '>= 16.04'
 supports 'centos', '>= 6.0'
 supports 'redhat', '>= 6.0'
 supports 'oracle', '>= 6.0'

--- a/recipes/auditd.rb
+++ b/recipes/auditd.rb
@@ -15,10 +15,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-service 'auditd' do
-  restart_command '/usr/libexec/initscripts/legacy-actions/auditd/restart' if platform_family?('rhel') && node['init_package'] == 'systemd'
-  supports [:start, :stop, :restart, :reload, :status]
-  action :nothing
+auditd_packages = case node['platform_family']
+                  when 'rhel'
+                    %w[audit audit-libs]
+                  when 'debian'
+                    %w[auditd audispd-plugins]
+                  end
+
+package 'auditd' do
+  package_name auditd_packages
 end
 
 cookbook_file '/etc/audit/auditd.conf' do
@@ -27,4 +32,10 @@ cookbook_file '/etc/audit/auditd.conf' do
   group 'root'
   mode '0640'
   notifies :restart, 'service[auditd]', :delayed
+end
+
+service 'auditd' do
+  restart_command '/usr/libexec/initscripts/legacy-actions/auditd/restart' if platform_family?('rhel') && node['init_package'] == 'systemd'
+  supports [:start, :stop, :restart, :reload, :status]
+  action :nothing
 end

--- a/recipes/awscli.rb
+++ b/recipes/awscli.rb
@@ -40,6 +40,7 @@ end
 
 execute 'install-aws-cli' do
   command '/tmp/install-aws-cli.sh'
+  cwd '/tmp'
   not_if 'which aws'
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,14 +19,21 @@
 
 # If the node name already has the domain component included, then use the node name itself; otherwise
 # use the domain.
-node.normal['set_fqdn'] = if Chef::Config[:node_name] =~ /#{node['system_core']['domain']}$/i
+
+# NOTE: This appends the domain name if the specified domain name is not part of the hostname, even if the hostname
+# already includes a domain name. e.g. if node['system_core']['domain'] is 'example.com' and the node_name is
+# 'host.mydomain.org', set_fqdn will be set to 'host.mydomain.org.example.com'
+# If the node_name contains a period do not append the node['system_core']['domain'] value.
+node.normal['set_fqdn'] = if Chef::Config[:node_name] =~ /#{node['system_core']['domain']}$/i ||
+                             Chef::Config[:node_name] =~ /.*\..*/
                             Chef::Config[:node_name]
                           else
                             "*.#{node['system_core']['domain']}"
                           end
 
 # The default is 127.0.1.1, which is used under Debian, not RHEL based systems.
-node.normal['hostname_cookbook']['hostsfile_ip'] = '127.0.0.1'
+node.normal['hostname_cookbook']['hostsfile_ip'] = '127.0.0.1' if node['platform_family'] == 'rhel'
+
 # Without this line, the 'hostname' cookbook sets:
 #  -127.0.0.1	full-oracle-73.linux.example.com full-oracle-73
 #  +127.0.0.1	full-oracle-73.linux.example.com full-oracle-73 localhost

--- a/recipes/ntp.rb
+++ b/recipes/ntp.rb
@@ -24,9 +24,3 @@ execute 'configure_ntp' do
   command 'rm /etc/localtime && ln -s /usr/share/zoneinfo/EST5EDT /etc/localtime'
   not_if '[ `readlink /etc/localtime` == "/usr/share/zoneinfo/EST5EDT" ]'
 end
-
-# TODO: Make the service name an attribute
-service 'ntpd' do
-  service_name 'ntpd'
-  action [:enable, :start]
-end

--- a/recipes/papertrail_remote.rb
+++ b/recipes/papertrail_remote.rb
@@ -1,0 +1,67 @@
+#
+# Cookbook Name:: system_core
+# Recipe:: papertrail
+#
+# Copyright (C) 2016 - 2017 Justin Spies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+if node['system_core']['papertrail']['enabled']
+  remote_file "#{Chef::Config['file_cache_path']}/remote_syslog2.rpm" do
+    source node['system_core']['papertrail']['remote_syslog2']['source_url']
+    owner 'root'
+    group 'root'
+    mode '0644'
+  end
+
+  package "#{Chef::Config['file_cache_path']}/remote_syslog2.rpm"
+
+  parts = node['system_core']['papertrail']['remote_host'].split(':')
+  pt_protocol = node['system_core']['papertrail']['remote_syslog2']['protocol']
+  pt_hostname = parts[0].gsub(/@/, '')
+  pt_port = if parts.length > 1
+              parts[1]
+            else
+              ''
+            end
+
+  hostname = if node['system_core']['papertrail']['remote_syslog2']['hostname'].nil?
+               node['hostname']
+             else
+               node['system_core']['papertrail']['remote_syslog2']['hostname']
+             end
+  remote_config = { hostname: hostname,
+                    files: node['system_core']['papertrail']['remote_syslog2']['files'],
+                    exclude_patterns: node['system_core']['papertrail']['remote_syslog2']['exclude_patterns'] }
+
+  template node['system_core']['papertrail']['remote_syslog2']['config']['file_name'] do
+    source node['system_core']['papertrail']['remote_syslog2']['config']['template_file']
+    owner 'root'
+    group 'root'
+    mode '0644'
+    variables(config: remote_config,
+              papertrail_host: pt_hostname,
+              papertrail_port: pt_port,
+              papertrail_protocol: pt_protocol)
+  end
+
+  service 'remote-syslog' do
+    action [:start, :enable]
+  end
+
+else
+  log 'papertrail-disabled' do
+    level :warn
+    message 'Papertrail is disabled via the node[system_core][papertrail][enabled] attribute and will not be configured'
+  end
+end

--- a/recipes/repos.rb
+++ b/recipes/repos.rb
@@ -20,6 +20,7 @@
 # Used to install various outside packages
 include_recipe 'yum'
 include_recipe 'yum-epel'
+include_recipe 'apt::default'
 
 # Avoid caching something we don't need cached.
 file '/etc/yum.repos.d/cobbler-config.repo' do

--- a/spec/platforms.rb
+++ b/spec/platforms.rb
@@ -1,5 +1,9 @@
 def platforms
   {
+    'ubuntu' => {
+      # CentOS versions don't 100% match those from Oracle Linux
+      'versions' => ['16.04']
+    },
     'centos' => {
       # CentOS versions don't 100% match those from Oracle Linux
       'versions' => ['6.8', '7.2.1511']

--- a/spec/unit/recipes/.rubocop.yml
+++ b/spec/unit/recipes/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_from: ../../../.rubocop.yml
 
 Metrics/BlockLength:
-  Max: 100
+  Max: 150

--- a/spec/unit/recipes/auditd_spec.rb
+++ b/spec/unit/recipes/auditd_spec.rb
@@ -5,7 +5,7 @@ describe 'system_core::auditd' do
     versions = details['versions']
     versions.each do |version|
       context "On #{platform} #{version}" do
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe)

--- a/spec/unit/recipes/awscli_spec.rb
+++ b/spec/unit/recipes/awscli_spec.rb
@@ -11,7 +11,7 @@ describe 'system_core::awscli' do
               stub_command('which aws').and_return(has_aws)
             end
 
-            let(:chef_run) do
+            cached(:chef_run) do
               runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
               runner.node.override['environment'] = 'dev'
               if has_profile

--- a/spec/unit/recipes/bash_spec.rb
+++ b/spec/unit/recipes/bash_spec.rb
@@ -5,7 +5,7 @@ describe 'system_core::bash' do
     versions = details['versions']
     versions.each do |version|
       context "On #{platform} #{version}" do
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe)

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -15,7 +15,7 @@ describe 'system_core::default' do
           end
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe)

--- a/spec/unit/recipes/hostname_spec.rb
+++ b/spec/unit/recipes/hostname_spec.rb
@@ -15,7 +15,7 @@ describe 'system_core::hostname' do
           end
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe)

--- a/spec/unit/recipes/ntp_spec.rb
+++ b/spec/unit/recipes/ntp_spec.rb
@@ -13,7 +13,7 @@ describe 'system_core::ntp' do
           stub_command("[ `readlink /etc/localtime` == \"/usr/share/zoneinfo/EST5EDT\" ]").and_return(false)
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe)
@@ -41,7 +41,7 @@ describe 'system_core::ntp' do
           stub_command("[ `readlink /etc/localtime` == \"/usr/share/zoneinfo/EST5EDT\" ]").and_return(true)
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe)

--- a/spec/unit/recipes/ntp_spec.rb
+++ b/spec/unit/recipes/ntp_spec.rb
@@ -28,10 +28,10 @@ describe 'system_core::ntp' do
           expect(chef_run).to run_execute 'configure_ntp'
         end
 
-        it 'should enable and start the NTP service' do
-          expect(chef_run).to enable_service 'ntpd'
-          expect(chef_run).to start_service 'ntpd'
-        end
+        # it 'should enable and start the NTP service' do
+        #   expect(chef_run).to enable_service 'ntpd'
+        #   expect(chef_run).to start_service 'ntpd'
+        # end
       end
 
       context "On #{platform} #{version} localtime is set and does not need updated" do
@@ -58,10 +58,10 @@ describe 'system_core::ntp' do
           expect(chef_run).to_not run_execute 'configure_ntp'
         end
 
-        it 'should enable and start the NTP service' do
-          expect(chef_run).to enable_service 'ntpd'
-          expect(chef_run).to start_service 'ntpd'
-        end
+        # it 'should enable and start the NTP service' do
+        #   expect(chef_run).to enable_service 'ntpd'
+        #   expect(chef_run).to start_service 'ntpd'
+        # end
       end
     end
   end

--- a/spec/unit/recipes/papertrail_remote_spec.rb
+++ b/spec/unit/recipes/papertrail_remote_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+describe 'system_core::papertrail_remote' do
+  packages = {
+    'centos' => {
+      'remote_syslog2' => '/tmp/remote_syslog2.rpm'
+    },
+    'oracle' => {
+      'remote_syslog2' => '/tmp/remote_syslog2.rpm'
+    }
+  }
+
+  # Used by Fauxhai to retrieve configuration details that are feed into ChefSpec; these correspond to
+  # specific URLs that must exist
+  platforms.each do |platform, details|
+    versions = details['versions']
+    versions.each do |version|
+      context "On #{platform} #{version} with papertrail enabled" do
+        cached(:chef_run) do
+          runner = ChefSpec::SoloRunner.new(platform: platform, version: version, file_cache_path: '/tmp')
+          runner.node.override['environment'] = 'dev'
+          runner.node.override['system_core']['papertrail']['enabled'] = true
+          runner.node.override['system_core']['papertrail']['remote_host'] = '@@logs.papertrailapp.com:12345'
+          runner.node.override['system_core']['papertrail']['remote_syslog2']['config']['file_name'] = '/etc/remote_syslog.conf'
+          runner.node.override['system_core']['papertrail']['remote_syslog2']['hostname'] = 'test-hostname'
+          runner.node.override['system_core']['papertrail']['remote_syslog2']['files'] = { '/etc/file1' => 'tag1',
+                                                                                           '/etc/file2' => nil }
+          runner.node.override['system_core']['papertrail']['remote_syslog2']['exclude_patterns'] = ['*pattern1*']
+
+          runner.converge(described_recipe)
+          # do
+          #   runner.resource_collection.insert(Chef::Resource::Service.new(packages[platform][''], runner.run_context))
+          # end
+        end
+
+        it "should download and install the #{packages[platform]['remote_syslog2']} package" do
+          expect(chef_run).to create_remote_file('/tmp/remote_syslog2.rpm')
+          expect(chef_run).to install_package packages[platform]['remote_syslog2']
+        end
+
+        it 'should create the remote_syslog configuration file' do
+          expect(chef_run).to create_template('/etc/remote_syslog.conf')
+        end
+
+        it 'should start and enable the remote_syslog service' do
+          expect(chef_run).to start_service('remote-syslog')
+          expect(chef_run).to enable_service('remote-syslog')
+        end
+
+        it 'should not display a log message at the warning level' do
+          expect(chef_run).to_not write_log('papertrail-disabled')
+        end
+      end
+
+      context "On #{platform} #{version} with papertrail disabled" do
+        cached(:chef_run) do
+          runner = ChefSpec::SoloRunner.new(platform: platform, version: version, file_cache_path: '/tmp')
+          runner.node.override['environment'] = 'dev'
+          runner.node.override['system_core']['papertrail']['enabled'] = false
+          runner.node.override['system_core']['papertrail']['remote_syslog2']['config']['file_name'] = '/etc/remote_syslog.conf'
+          runner.converge(described_recipe)
+          # do
+          #   runner.resource_collection.insert(Chef::Resource::Service.new(packages[platform][''], runner.run_context))
+          # end
+        end
+
+        it "should not download and install the #{packages[platform]['remote_syslog2']} package" do
+          expect(chef_run).to_not create_remote_file('/tmp/remote_syslog2.rpm')
+          expect(chef_run).to_not install_package packages[platform]['remote_syslog2']
+        end
+
+        it 'should not create the remote_syslog configuration file' do
+          expect(chef_run).to_not create_template('/etc/remote_syslog.conf')
+        end
+
+        it 'should start and enable the remote_syslog service' do
+          expect(chef_run).to_not start_service('remote-syslog')
+          expect(chef_run).to_not enable_service('remote-syslog')
+        end
+
+        it 'should display a log message at the warning level' do
+          expect(chef_run).to write_log('papertrail-disabled').with(level: :warn)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/recipes/papertrail_remote_spec.rb
+++ b/spec/unit/recipes/papertrail_remote_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 describe 'system_core::papertrail_remote' do
   packages = {
+    'ubuntu' => {
+      'remote_syslog2' => '/tmp/remote_syslog2.rpm'
+    },
     'centos' => {
       'remote_syslog2' => '/tmp/remote_syslog2.rpm'
     },

--- a/spec/unit/recipes/papertrail_spec.rb
+++ b/spec/unit/recipes/papertrail_spec.rb
@@ -23,7 +23,7 @@ describe 'system_core::papertrail' do
           allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('system_core::rsyslog')
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.node.override['system_core']['papertrail']['enabled'] = true
@@ -76,7 +76,7 @@ describe 'system_core::papertrail' do
           allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('system_core::rsyslog')
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.node.override['system_core']['papertrail']['enabled'] = false

--- a/spec/unit/recipes/papertrail_spec.rb
+++ b/spec/unit/recipes/papertrail_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 describe 'system_core::papertrail' do
   packages = {
+    'ubuntu' => {
+      'gnutls-package' => 'rsyslog-gnutls',
+      'rsyslog-service' => 'rsyslog'
+    },
     'centos' => {
       'gnutls-package' => 'rsyslog-gnutls',
       'rsyslog-service' => 'rsyslog'

--- a/spec/unit/recipes/postfix_spec.rb
+++ b/spec/unit/recipes/postfix_spec.rb
@@ -11,7 +11,7 @@ describe 'system_core::postfix' do
           allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('postfix')
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe)

--- a/spec/unit/recipes/rbenv_spec.rb
+++ b/spec/unit/recipes/rbenv_spec.rb
@@ -7,7 +7,7 @@ describe 'system_core::rbenv' do
     versions = details['versions']
     versions.each do |version|
       context "On #{platform} #{version}" do
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe)

--- a/spec/unit/recipes/repos_spec.rb
+++ b/spec/unit/recipes/repos_spec.rb
@@ -14,7 +14,7 @@ describe 'system_core::repos' do
           stub_command("yum list installed|grep mysql55w-libs").and_return(false)
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.default['environment'] = 'dev'
           runner.converge(described_recipe)
@@ -65,7 +65,7 @@ describe 'system_core::repos' do
           stub_command("yum list installed|grep mysql55w-libs").and_return(true)
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.default['environment'] = 'dev'
           runner.converge(described_recipe)

--- a/spec/unit/recipes/repos_spec.rb
+++ b/spec/unit/recipes/repos_spec.rb
@@ -11,6 +11,7 @@ describe 'system_core::repos' do
           # Mock accepting the include_recipe commands
           allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('yum')
           allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('yum-epel')
+          allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('apt::default')
           stub_command("yum list installed|grep mysql55w-libs").and_return(false)
         end
 
@@ -27,6 +28,7 @@ describe 'system_core::repos' do
         it 'should call the necessary YUM recipes' do
           expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('yum')
           expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('yum-epel')
+          expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('apt::default')
 
           chef_run
         end
@@ -62,6 +64,7 @@ describe 'system_core::repos' do
           # Mock accepting the include_recipe commands
           allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('yum')
           allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('yum-epel')
+          allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('apt::default')
           stub_command("yum list installed|grep mysql55w-libs").and_return(true)
         end
 
@@ -78,6 +81,7 @@ describe 'system_core::repos' do
         it 'should call the necessary YUM recipes' do
           expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('yum')
           expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('yum-epel')
+          expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('apt::default')
 
           chef_run
         end

--- a/spec/unit/recipes/rsyslog_spec.rb
+++ b/spec/unit/recipes/rsyslog_spec.rb
@@ -9,7 +9,7 @@ describe 'system_core::rsyslog' do
           allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('rsyslog')
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe) do

--- a/spec/unit/recipes/selinux_spec.rb
+++ b/spec/unit/recipes/selinux_spec.rb
@@ -10,7 +10,7 @@ describe 'system_core::selinux' do
           allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('selinux::disabled')
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe)

--- a/spec/unit/recipes/ssh_spec.rb
+++ b/spec/unit/recipes/ssh_spec.rb
@@ -10,7 +10,7 @@ describe 'system_core::ssh' do
           allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('sudo')
         end
 
-        let(:chef_run) do
+        cached(:chef_run) do
           runner = ChefSpec::SoloRunner.new(platform: platform, version: version)
           runner.node.override['environment'] = 'dev'
           runner.converge(described_recipe)

--- a/templates/default/log_files.yaml.erb
+++ b/templates/default/log_files.yaml.erb
@@ -1,0 +1,22 @@
+<% if @config['hostname'] -%>
+hostname: <%= @config['hostname'] %>
+<% end -%>
+files:
+<% @config['files'].each do |file, tag|
+  - path: <%= file %>
+<%   unless tag.nil? -%>
+    tag: <%= tag %>
+<%   end
+   end
+-%>
+destination:
+  host: <%= @papertrail_host %>
+  port: <%= @papertrail_port %>
+  protocol: <%= @papertrail_protocol %>
+<% if @config.key?('exclude_patterns') -%>
+exclude_patterns:
+<%   @config['exclude_patterns'].each do |pattern|
+  - <%= pattern %>
+<%   end
+   end
+-%>

--- a/templates/default/log_files.yaml.erb
+++ b/templates/default/log_files.yaml.erb
@@ -2,11 +2,13 @@
 hostname: <%= @config['hostname'] %>
 <% end -%>
 files:
-<% @config['files'].each do |file, tag|
+<% if @config.key('files')
+     @config['files'].each do |file, tag| -%>
   - path: <%= file %>
-<%   unless tag.nil? -%>
+<%     unless tag.nil? -%>
     tag: <%= tag %>
-<%   end
+<%     end
+     end
    end
 -%>
 destination:
@@ -15,7 +17,7 @@ destination:
   protocol: <%= @papertrail_protocol %>
 <% if @config.key?('exclude_patterns') -%>
 exclude_patterns:
-<%   @config['exclude_patterns'].each do |pattern|
+<%   @config['exclude_patterns'].each do |pattern| -%>
   - <%= pattern %>
 <%   end
    end

--- a/test/integration/.rubocop.yml
+++ b/test/integration/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../../.rubocop.yml
+
+Metrics/BlockLength:
+  Max: 150

--- a/test/integration/altdomain/inspec/controls/linux-baseline.rb
+++ b/test/integration/altdomain/inspec/controls/linux-baseline.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Style/FileName
+# rubocop:disable Naming/FileName
 
 # While this could be done via .kitchen.yml, as of 2018-01-26 the linux-baseline controls do not use attributes
 # to enable/disable IPv6 and IPv6 forwarding. Because we want those turned on and don't want the configuration reported
@@ -14,3 +14,5 @@ include_controls 'linux-baseline' do
 end
 
 include_controls 'system-baseline'
+
+# rubocop:enable Naming/FileName

--- a/test/integration/altdomain/inspec/controls/linux-baseline.rb
+++ b/test/integration/altdomain/inspec/controls/linux-baseline.rb
@@ -1,18 +1,9 @@
 # rubocop:disable Naming/FileName
 
-# While this could be done via .kitchen.yml, as of 2018-01-26 the linux-baseline controls do not use attributes
-# to enable/disable IPv6 and IPv6 forwarding. Because we want those turned on and don't want the configuration reported
-# as an error, it is necessary to skip those controls below as the ability to skip controls is not possible with
-# Test Kitchen.
-include_controls 'linux-baseline' do
-  # This host requires IPv4 forwarding
-  skip_control 'sysctl-01'
-  # This host requires IPv6
-  skip_control 'sysctl-18'
-  # This host requires IPv6 forwarding
-  skip_control 'sysctl-19'
+include_controls 'system-baseline' do
+  skip_control 'papertrail' # not included in altdomain tests
+  skip_control 'sshkeys' # not included in altdomain tests
+  skip_control 'ntp-services' # not included in altdomain tests
 end
-
-include_controls 'system-baseline'
 
 # rubocop:enable Naming/FileName

--- a/test/integration/altdomain/inspec/inspec.yml
+++ b/test/integration/altdomain/inspec/inspec.yml
@@ -8,8 +8,10 @@ summary: Verifies configuration of core services and components for Linux system
 version: 1.0.0
 supports:
   - os-family: redhat
+  - os-family: debian
 depends:
   - name: linux-baseline
     url: https://github.com/dev-sec/linux-baseline
   - name: system-baseline
     url: https://github.com/eyespies/system-baseline
+    # path: ../../../inspec/system-baseline

--- a/test/integration/base/inspec/controls/linux-baseline.rb
+++ b/test/integration/base/inspec/controls/linux-baseline.rb
@@ -1,18 +1,7 @@
 # rubocop:disable Naming/FileName
 
-# While this could be done via .kitchen.yml, as of 2018-01-26 the linux-baseline controls do not use attributes
-# to enable/disable IPv6 and IPv6 forwarding. Because we want those turned on and don't want the configuration reported
-# as an error, it is necessary to skip those controls below as the ability to skip controls is not possible with
-# Test Kitchen.
-include_controls 'linux-baseline' do
-  # This host requires IPv4 forwarding
-  skip_control 'sysctl-01'
-  # This host requires IPv6
-  skip_control 'sysctl-18'
-  # This host requires IPv6 forwarding
-  skip_control 'sysctl-19'
+include_controls 'system-baseline' do
+  skip_control 'papertrail' # not included in base tests
 end
-
-include_controls 'system-baseline'
 
 # rubocop:enable Naming/FileName

--- a/test/integration/base/inspec/controls/linux-baseline.rb
+++ b/test/integration/base/inspec/controls/linux-baseline.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Style/FileName
+# rubocop:disable Naming/FileName
 
 # While this could be done via .kitchen.yml, as of 2018-01-26 the linux-baseline controls do not use attributes
 # to enable/disable IPv6 and IPv6 forwarding. Because we want those turned on and don't want the configuration reported
@@ -14,3 +14,5 @@ include_controls 'linux-baseline' do
 end
 
 include_controls 'system-baseline'
+
+# rubocop:enable Naming/FileName

--- a/test/integration/base/inspec/inspec.yml
+++ b/test/integration/base/inspec/inspec.yml
@@ -8,8 +8,10 @@ summary: Verifies configuration of core services and components for Linux system
 version: 1.0.0
 supports:
   - os-family: redhat
+  - os-family: debian
 depends:
   - name: linux-baseline
     url: https://github.com/dev-sec/linux-baseline
   - name: system-baseline
     url: https://github.com/eyespies/system-baseline
+    # path: ../../../inspec/system-baseline

--- a/test/integration/logging/inspec/controls/linux-baseline.rb
+++ b/test/integration/logging/inspec/controls/linux-baseline.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Style/FileName
+# rubocop:disable Naming/FileName
 
 # While this could be done via .kitchen.yml, as of 2018-01-26 the linux-baseline controls do not use attributes
 # to enable/disable IPv6 and IPv6 forwarding. Because we want those turned on and don't want the configuration reported
@@ -14,3 +14,5 @@ include_controls 'linux-baseline' do
 end
 
 include_controls 'system-baseline'
+
+# rubocop:enable Naming/FileName

--- a/test/integration/logging/inspec/controls/linux-baseline.rb
+++ b/test/integration/logging/inspec/controls/linux-baseline.rb
@@ -1,7 +1,0 @@
-# rubocop:disable Naming/FileName
-
-include_controls 'system-baseline' do
-  skip_control 'sshkeys' # not included in altdomain tests
-end
-
-# rubocop:enable Naming/FileName

--- a/test/integration/logging/inspec/controls/linux-baseline.rb
+++ b/test/integration/logging/inspec/controls/linux-baseline.rb
@@ -1,18 +1,7 @@
 # rubocop:disable Naming/FileName
 
-# While this could be done via .kitchen.yml, as of 2018-01-26 the linux-baseline controls do not use attributes
-# to enable/disable IPv6 and IPv6 forwarding. Because we want those turned on and don't want the configuration reported
-# as an error, it is necessary to skip those controls below as the ability to skip controls is not possible with
-# Test Kitchen.
-include_controls 'linux-baseline' do
-  # This host requires IPv4 forwarding
-  skip_control 'sysctl-01'
-  # This host requires IPv6
-  skip_control 'sysctl-18'
-  # This host requires IPv6 forwarding
-  skip_control 'sysctl-19'
+include_controls 'system-baseline' do
+  skip_control 'sshkeys' # not included in altdomain tests
 end
-
-include_controls 'system-baseline'
 
 # rubocop:enable Naming/FileName

--- a/test/integration/logging/inspec/controls/papertrail_remote.rb
+++ b/test/integration/logging/inspec/controls/papertrail_remote.rb
@@ -1,0 +1,63 @@
+# Copyright (C) 2016 - 2017 Justin Spies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+papertrail_host = attribute('papertrail_host',
+  default: nil,
+  description: 'Hostname to be compared when testing that papertrail is properly configured')
+
+control 'remote-syslog' do
+  impact 1.0
+  title 'Validates the Remote Syslog package from Papertrail'
+  desc 'Ensures that the remote-syslog2 package is installed for use with forwarding arbitrary log data to Papertrail'
+
+  package_name = case os.name
+                 when 'redhat', 'centos', 'oracle'
+                   'remote_syslog2'
+                 when 'debian', 'ubuntu'
+                   'remote-syslog2'
+                 end
+
+  describe package(package_name) do
+    it { should be_installed }
+  end
+
+  describe file('/etc/log_files.yaml') do
+    it { should exist }
+    it { should be_owned_by('root') }
+    it { should be_grouped_into('root') }
+    its('mode') { should cmp '0644' }
+  end
+
+  describe file('/etc/papertrail-bundle.pem') do
+    it { should exist }
+    it { should be_owned_by('root') }
+    it { should be_grouped_into('root') }
+    its('mode') { should cmp '0644' }
+  end
+
+  describe file('/etc/rsyslog.d/22-papertrail.conf') do
+    it { should exist }
+    it { should be_owned_by('root') }
+    it { should be_grouped_into('root') }
+    its('mode') { should cmp '0644' }
+    its(:content) { should match(/\*\.\*\s*#{papertrail_host}$/i) }
+  end
+
+  describe service('remote_syslog') do
+    it { should be_enabled }
+    it { should be_running }
+  end
+
+  only_if { !papertrail_host.nil? }
+end

--- a/test/integration/logging/inspec/inspec.yml
+++ b/test/integration/logging/inspec/inspec.yml
@@ -8,8 +8,10 @@ summary: Verifies configuration of core services and components for Linux system
 version: 1.0.0
 supports:
   - os-family: redhat
+  - os-family: debian
 depends:
   - name: linux-baseline
     url: https://github.com/dev-sec/linux-baseline
   - name: system-baseline
-    url: https://github.com/eyespies/system-baseline
+    # url: https://github.com/eyespies/system-baseline
+    path: ../../../inspec/system-baseline

--- a/test/integration/logging/inspec/inspec.yml
+++ b/test/integration/logging/inspec/inspec.yml
@@ -12,6 +12,3 @@ supports:
 depends:
   - name: linux-baseline
     url: https://github.com/dev-sec/linux-baseline
-  - name: system-baseline
-    # url: https://github.com/eyespies/system-baseline
-    path: ../../../inspec/system-baseline

--- a/test/integration/ruby/inspec/controls/linux-baseline.rb
+++ b/test/integration/ruby/inspec/controls/linux-baseline.rb
@@ -1,18 +1,7 @@
 # rubocop:disable Naming/FileName
 
-# While this could be done via .kitchen.yml, as of 2018-01-26 the linux-baseline controls do not use attributes
-# to enable/disable IPv6 and IPv6 forwarding. Because we want those turned on and don't want the configuration reported
-# as an error, it is necessary to skip those controls below as the ability to skip controls is not possible with
-# Test Kitchen.
-include_controls 'linux-baseline' do
-  # This host requires IPv4 forwarding
-  skip_control 'sysctl-01'
-  # This host requires IPv6
-  skip_control 'sysctl-18'
-  # This host requires IPv6 forwarding
-  skip_control 'sysctl-19'
+include_controls 'system-baseline' do
+  skip_control 'papertrail' # not included in base tests
 end
-
-include_controls 'system-baseline'
 
 # rubocop:enable Naming/FileName

--- a/test/integration/ruby/inspec/controls/linux-baseline.rb
+++ b/test/integration/ruby/inspec/controls/linux-baseline.rb
@@ -1,7 +1,0 @@
-# rubocop:disable Naming/FileName
-
-include_controls 'system-baseline' do
-  skip_control 'papertrail' # not included in base tests
-end
-
-# rubocop:enable Naming/FileName

--- a/test/integration/ruby/inspec/controls/linux-baseline.rb
+++ b/test/integration/ruby/inspec/controls/linux-baseline.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Style/FileName
+# rubocop:disable Naming/FileName
 
 # While this could be done via .kitchen.yml, as of 2018-01-26 the linux-baseline controls do not use attributes
 # to enable/disable IPv6 and IPv6 forwarding. Because we want those turned on and don't want the configuration reported
@@ -14,3 +14,5 @@ include_controls 'linux-baseline' do
 end
 
 include_controls 'system-baseline'
+
+# rubocop:enable Naming/FileName

--- a/test/integration/ruby/inspec/controls/ruby.rb
+++ b/test/integration/ruby/inspec/controls/ruby.rb
@@ -1,0 +1,37 @@
+# Copyright (C) 2016 - 2017 Justin Spies
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+control 'ruby' do
+  impact 1.0
+  title 'Validates the Remote Syslog package from Papertrail'
+  desc 'Ensures that the remote-syslog2 package is installed for use with forwarding arbitrary log data to Papertrail'
+
+  describe package('bzip2') do
+    it { should be_installed }
+  end
+
+  describe file('/usr/local/rbenv/shims/ruby') do
+    it { should exist }
+    it { should be_owned_by('root') }
+    it { should be_grouped_into('root') }
+    its('mode') { should cmp '0755' }
+  end
+
+  describe file('/root/.gemrc') do
+    it { should exist }
+    it { should be_owned_by('root') }
+    it { should be_grouped_into('root') }
+    its('mode') { should cmp '0644' }
+  end
+end

--- a/test/integration/ruby/inspec/inspec.yml
+++ b/test/integration/ruby/inspec/inspec.yml
@@ -12,6 +12,3 @@ supports:
 depends:
   - name: linux-baseline
     url: https://github.com/dev-sec/linux-baseline
-  - name: system-baseline
-    url: https://github.com/eyespies/system-baseline
-    # path: ../../../inspec/system-baseline

--- a/test/integration/ruby/inspec/inspec.yml
+++ b/test/integration/ruby/inspec/inspec.yml
@@ -8,8 +8,10 @@ summary: Verifies configuration of core services and components for Linux system
 version: 1.0.0
 supports:
   - os-family: redhat
+  - os-family: debian
 depends:
   - name: linux-baseline
     url: https://github.com/dev-sec/linux-baseline
   - name: system-baseline
     url: https://github.com/eyespies/system-baseline
+    # path: ../../../inspec/system-baseline


### PR DESCRIPTION
### Description

- Add support for Ubuntu 16 OS
- Add papertrail_remote recipe and corresponding unit/integration tests
- Add audit recipe for configuration of Auditd within guidelines from [Linux Baseline](https://github.com/dev-sec/linux-baseline) security

### Issues Resolved

#2 

### Check List

- [x] All tests pass on local environment (Travis is failing due to long running unit tests)
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
