### PR TITLE
Develop

### DIFF
--- a/.kitchen-ec2.yml
+++ b/.kitchen-ec2.yml
@@ -1,0 +1,155 @@
+---
+driver:
+  name: ec2
+  customize:
+    memory: 1024
+    cpus: 1
+
+provisioner:
+  product_name: chef
+  product_version: "<%= ENV.has_key?('CHEF_VERSION') ? ENV['CHEF_VERSION'] : 14 %>"
+  # You may wish to disable always updating cookbooks in CI or other testing environments.
+  # For example:
+  #   always_update_cookbooks: <%= !ENV['CI'] %>
+  always_update_cookbooks: true
+  chef_license: accept
+  # log_level: info
+
+verifier:
+  name: inspec
+
+platforms:
+  - name: ubuntu-16.04
+    driver:
+      image_search:
+        owner-id: "099720109477"
+        name: "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04"
+  - name: ubuntu-18.04
+    driver:
+      image_search:
+        owner-id: "099720109477"
+        name: "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04"
+  - name: centos-6.10
+    driver:
+      image_search:
+        owner-id: "679593333241"
+        name: "CentOS Linux 6 x86_64"
+  - name: centos-7.7
+    driver:
+      image_search:
+        owner-id: "679593333241"
+        name: "CentOS Linux 7 x86_64"
+  # Not available yet, see https://bugs.centos.org/view.php?id=16614
+  # - name: centos-8.1
+  #   driver:
+  #     image_search:
+  #       owner-id: "679593333241"
+  #       name: "CentOS Linux 8 x86_64"
+  - name: oracle-6.10
+    driver:
+      image_search:
+        owner-id: "131827586825"
+        name: "OL6.10"
+  - name: oracle-7.6
+    driver:
+      image_search:
+        owner-id: "131827586825"
+        name: "OL7.6"
+  - name: oracle-8.1
+    driver:
+      image_search:
+        owner-id: "131827586825"
+        name: "OL8.1"
+
+suites:
+  - name: base
+    data_bags_path: "../../data_bags"
+    run_list:
+      - recipe[system_core::default]
+      # This seems to be automatically installed by RHEL / CentOS / Oracle,
+      # but not by Debian, which causes the Debian tests to fail because they
+      # are looking for auditd
+      - recipe[system_core::auditd]
+      - recipe[system_core::repos]
+      - recipe[system_core::awscli]
+      - recipe[system_core::bash]
+      - recipe[system_core::postfix]
+      - recipe[system_core::ntp]
+      - recipe[system_core::selinux]
+      - recipe[system_core::ssh]
+      - recipe[system_core::logrotate]
+      - recipe[system_core::user_ssh]
+    attributes:
+      system_core:
+        ssh:
+          authorized_keys:
+            root:
+              public_key: "AAAAB3NzaC1yc2EAAAADAQABAAABAQDJlvaL0I0HWNE/RblFscFWhjXDwX6UaMBLtG5YdbHHSc1QQO+W+kV15q3T7WnED6In+aK423OzMTk/0/UZrchlxa2KCRNSnRrqViTZZ1XUXwEXqCnBQ9O1El93AAaE73suB9kYfeO105D5AgTTmf41HDc4YAxZtoAOt2KdI2GF7+7IfheI54aWSldmQesfqNloY+ivYIOhyEIwXuO9RS2BEbrFoxuVfOcz62AGcFz07EsALWGNzr4ngT6pe8vCbV5s/f0cDk5z9XZ4Wk2uQI7NQuLkSOmokU3QqZhOYJUjjTdq8VrjARWdF7K5N0/LQ/Wyx6Tgy+XRavnmj/SMhaKd"
+              user: 'root'
+          user_config:
+            root:
+              hosts:
+                \*:
+                  SendEnv: "LANG LC_*"
+                  ForwardAgent: "yes"
+                  UserKnownHostsFile: "/dev/null"
+                  StrictHostKeyChecking: "no"
+              keys:
+                id_rsa:
+                  owner: root
+                  ssh_key_bucket: "<%= ENV['SSH_KEY_BUCKET'] %>"
+                  ssh_key_path: "<%= ENV.key?('ROOT_SSH_KEY_PATH') ? ENV['ROOT_SSH_KEY_PATH'] : 'ssh-keys/root' %>"
+        aws:
+          profiles:
+            default:
+              output_format: "json"
+              region: "<%= ENV.key('AWS_REGION') ? ENV['AWS_REGION'] : 'us-east-1' %>"
+              access_key: "<%= ENV['AWS_ACCESS_KEY_ID'] %>"
+              secret_key: "<%= ENV['AWS_SECRET_ACCESS_KEY'] %>"
+  - name: logging
+    data_bags_path: "../../data_bags"
+    run_list:
+      - recipe[system_core::default]
+      - recipe[system_core::rsyslog]
+      - recipe[system_core::logrotate]
+      - recipe[system_core::papertrail]
+      - recipe[system_core::papertrail_remote]
+      - recipe[logrotate::default]
+    verifier:
+      attributes:
+        papertrail_host: '@@log.example.com:11111'
+    attributes:
+      system_core:
+        papertrail:
+          enabled: true
+          remote_host: '@@log.example.com:11111'
+          remote_syslog2:
+            files:
+              /some/file/without-tags:
+              /some/file/with-tag: 'test'
+              /some/second/file/with-tag: 'test'
+              /some/third/file/with-tag: 'test'
+              /some/second/file/without-tags:
+  - name: ruby
+    data_bags_path: "../../data_bags"
+    run_list:
+      - recipe[system_core::default]
+      - recipe[system_core::rbenv]
+  - name: altdomain
+    data_bags_path: "../../data_bags"
+    run_list:
+      - recipe[system_core::default]
+      - recipe[system_core::repos]
+    verifier:
+      attributes:
+        default_domain: linux.alt.org
+    attributes:
+      system_core:
+        aws:
+          profiles:
+            default:
+              output_format: "json"
+              region: "<%= ENV.key('AWS_REGION') ? ENV['AWS_REGION'] : 'us-east-1' %>"
+              access_key: "<%= ENV['AWS_ACCESS_KEY_ID'] %>"
+              secret_key: "<%= ENV['AWS_SECRET_ACCESS_KEY'] %>"
+        domain: "linux.alt.org"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,8 +6,14 @@ driver:
     cpus: 1
 
 provisioner:
-  name: chef_zero
-  require_chef_omnibus: "<%= ENV.has_key?('CHEF_VERSION') ? ENV['CHEF_VERSION'] : true %>"
+  product_name: chef
+  product_version: "<%= ENV.has_key?('CHEF_VERSION') ? ENV['CHEF_VERSION'] : 14 %>"
+  # You may wish to disable always updating cookbooks in CI or other testing environments.
+  # For example:
+  #   always_update_cookbooks: <%= !ENV['CI'] %>
+  always_update_cookbooks: true
+  chef_license: accept
+  # log_level: info
 
 verifier:
   name: inspec
@@ -15,12 +21,11 @@ verifier:
 platforms:
   - name: ubuntu-16.04
   - name: ubuntu-18.04
-  - name: centos-6.9
-  - name: centos-7.5
-  - name: oracle-6.9
-  - name: oracle-7.5
-    driver_config:
-      box: bento/oracle-7.5
+  - name: centos-6.10
+  - name: centos-7.7
+  - name: oracle-6.10
+  - name: oracle-7.7
+  - name: oracle-8.1
 
 suites:
   - name: base
@@ -95,6 +100,7 @@ suites:
     data_bags_path: "../../data_bags"
     run_list:
       - recipe[system_core::default]
+      - recipe[system_core::repos]
       - recipe[system_core::rbenv]
   - name: altdomain
     data_bags_path: "../../data_bags"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,59 @@
 # system_core Cookbook Change Log
 
+## 4.0.0
+
+- Justin Spies - (breaking) upgrade default Ruby version from 2.2.2 to 2.6.5
+- Justin Spies - (breaking) upgrade apt to 7.2.0 from 6.0, iptables to 6.0.0 from 4.2.0
+- Justin Spies - (feature) upgrade numerous dependencies to newest feature release (see metadata.rb for details)
+- Justin Spies - (feature) add UEK5 repo URL
+- Justin Spies - (feature) increment all OS versions; add Ubuntu 18.04 and CentOS 8 to platform list
+- Justin Spies - (fix) do not test hostname in the base tests - Vagrant / VirtualBox defaults to no domain name
+- Justin Spies - (fix) defect that was breaking ssh_authorized_keys unit tests
+
 ## 3.0.1
-- (security) eliminate insecure SSH Ciphers
+
+- Justin Spies - (security) eliminate insecure SSH Ciphers
 
 ## 3.0.0
-- Update to latest yum-epel and yum cookbooks
-- Remove / update platforms that are now deprecated
-- Fauxhai 6.7.0 is now Chef 14.x based (from the previous Chef 13.x) at least for Oracle; this broke the SSH vagrant lookup; fixed
+
+- Justin Spies - Update to latest yum-epel and yum cookbooks
+- Justin Spies - Remove / update platforms that are now deprecated
+- Justin Spies - Fauxhai 6.7.0 is now Chef 14.x based (from the previous Chef 13.x) at least for Oracle; this broke the SSH vagrant lookup; fixed
 
 ## 2.1.5
-- Fix broken unit test
+
+- Justin Spies - Fix broken unit test
 
 ## 2.1.4
-- Use default to set sudo attributes so they can be overridden in JSON files
+
+- Justin Spies - Use default to set sudo attributes so they can be overridden in JSON files
 
 ## 2.1.3
-- Use default to set the allow_groups for SSH so that downstream cookbooks can change the values even with JSON files
+
+- Justin Spies - Use default to set the allow_groups for SSH so that downstream cookbooks can change the values even with JSON files
 
 ## 2.1.2
-- Use normal, not override, when setting allow_groups for SSH so that downstream cookbooks can change the values even with JSON files
+
+- Justin Spies - Use normal, not override, when setting allow_groups for SSH so that downstream cookbooks can change the values even with JSON files
 
 ## 2.1.1
-- Fix incorrect configuration file name for remote_syslog2
+
+- Justin Spies - Fix incorrect configuration file name for remote_syslog2
 
 ## 2.1.0
-- Allow specifying the timezone to use
+
+- Justin Spies - Allow specifying the timezone to use
 
 ## 2.0.0
-- Add support for Ubuntu 16 OS
-- Add papertrail_remote recipe and corresponding unit/integration tests
-- Add audit recipe for configuration of Auditd within guidelines from [Linux Baseline](https://github.com/dev-sec/linux-baseline) security
+
+- Justin Spies - Add support for Ubuntu 16 OS
+- Justin Spies - Add papertrail_remote recipe and corresponding unit/integration tests
+- Justin Spies - Add audit recipe for configuration of Auditd within guidelines from [Linux Baseline](https://github.com/dev-sec/linux-baseline) security
 
 ## 1.1.0
-- Add basic configuration of auditd to match dev sec standards; current configuration does not use a template and thus is fixed
+
+- Justin Spies - Add basic configuration of auditd to match dev sec standards; current configuration does not use a template and thus is fixed
 
 ## 1.0.0
-- Add attribute that allows disabling the use of papertrail; set to enabled by default to maintain backwards compatibility
+
+- Justin Spies - Add attribute that allows disabling the use of papertrail; set to enabled by default to maintain backwards compatibility

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-system_core Cookbook
-=======================
+# system_core Cookbook
+
 Performs general system configuration that is core to all servers. Also provides some attributes that are
 leveraged by other cookbooks, although attempts aremade to limit such dependencies. Examples of 'core'
 configuration including SSH, the AWS CLI, bash customizations, logrotate, NTP, rsyslog, selinux, and mail
@@ -8,9 +8,10 @@ server configuration.
 *Note* that this cookbook depends and a number of other cookbooks to perform the actual work, this is
 essentially just a wrapper around those cookbooks.
 
-Requirements
-------------
-#### cookbooks
+## Requirements
+
+### cookbooks
+
 - awscli
 - bzip2
 - hostnames
@@ -30,7 +31,8 @@ Requirements
 - yum
 - yum-epel
 
-#### packages
+### packages
+
 - `curl` - for when files are needed from FTP / HTTP / etc
 - `logrotate` - used to keep the disks from filling up with big log files
 - `jq` - enables processing JSON from shell scripts
@@ -42,14 +44,15 @@ Requirements
 - `wget` - an alternative to `curl`
 - `yum` - package management for RHEL / CentOS / Oracle family
 
-Attributes
-----------
+## Attributes
+
 Attributes are available from the various files in the _attributes/_ path, please review the files there
 for all details about attributes.
 
-Usage
------
-#### system_core::default
+## Usage
+
+### system_core::default
+
 TODO: Write usage instructions for each recipe.
 
 e.g.
@@ -64,6 +67,6 @@ Just include `system_core` in your node's `run_list`:
 }
 ```
 
-License and Authors
--------------------
+## License and Authors
+
 Authors: Justin Spies <justin@thespies.org>

--- a/attributes/repos.rb
+++ b/attributes/repos.rb
@@ -20,3 +20,4 @@
 node.default['system_core']['repos']['ol7_base_latest']['url']     = 'http://yum.oracle.com/repo/OracleLinux/OL7/latest/$basearch/'
 node.default['system_core']['repos']['ol7_uek4_latest']['url']     = 'http://yum.oracle.com/repo/OracleLinux/OL7/UEKR4/$basearch/'
 node.default['system_core']['repos']['ol7_optional_latest']['url'] = 'http://yum.oracle.com/repo/OracleLinux/OL7/optional/latest/$basearch/'
+node.default['system_core']['repos']['ol7_uek5_latest']['url']     = 'http://yum.oracle.com/repo/OracleLinux/OL7/UEKR5/$basearch/'

--- a/attributes/ruby.rb
+++ b/attributes/ruby.rb
@@ -18,5 +18,5 @@
 #
 
 # ~ ruby ~ #
-node.default['system_core']['ruby']['global']  = '2.2.2'
+node.default['system_core']['ruby']['global']  = '2.6.5'
 node.default['system_core']['ruby']['gems']    = %w[bundler]

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,27 +6,28 @@ issues_url       'https://github.com/eyespies/system_core/issues'
 license          'Apache-2.0'
 description      'Core operating system configuration for Enterprise Linux'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.0'
+version          '4.0.0'
 chef_version     '>= 12'
 
-depends 'apt', '~> 6.0'
+depends 'apt', '~> 7.2.0'
 # This is the 3ofcoins version and is the one from which all others are forked. Tried using the 'hostnames' version
 # from nathantsoi, however it does not properly support Oracle Linux. It also generates Chef warnings and although a
 # PR was submitted in January 2017 to eliminate the warnings, as of August 2017 the maintainer has not merged the PR.
 # So it seems the nathantsoi version is no longer maintained.
 depends 'hostname', '~> 0.4.0'
-depends 'iptables', '~> 4.2.0'
+depends 'iptables', '~> 6.0.0'
 depends 'logrotate', '~> 2.2.0'
-depends 'ntp', '~> 3.5.0'
-depends 'openssh', '~> 2.4.0'
-depends 'postfix', '~> 5.1.0'
-depends 'ruby_rbenv', '~> 2.0.0'
-depends 'rsyslog', '~> 6.0.0'
+depends 'ntp', '~> 3.7.0'
+depends 'openssh', '~> 2.8.0'
+depends 'postfix', '~> 5.3.0'
+depends 'ruby_rbenv', '~> 2.3.0'
+depends 'rsyslog', '~> 7.0.0'
+# TODO: Switch to aws cookbook
 depends 's3_file', '~> 2.8.0'
-depends 'selinux', '~> 2.0.0'
+depends 'selinux', '~> 3.0.0'
 depends 'ssh_authorized_keys', '~> 0.4.0'
 depends 'ssh_known_hosts', '~> 5.2.0'
-depends 'sudo', '~> 3.5.0'
+depends 'sudo', '~> 5.4.0'
 depends 'yum', '~> 5.1.0'
 depends 'yum-epel', '~> 3.3.0'
 

--- a/spec/platforms.rb
+++ b/spec/platforms.rb
@@ -1,15 +1,15 @@
+# See https://github.com/chefspec/fauxhai/blob/master/PLATFORMS.md for list of platforms
 def platforms
   {
     'ubuntu' => {
-      # CentOS versions don't 100% match those from Oracle Linux
-      'versions' => ['16.04']
+      'versions' => ['16.04', '18.04']
     },
     'centos' => {
       # CentOS versions don't 100% match those from Oracle Linux
-      'versions' => ['6.8', '7.5.1804']
+      'versions' => ['6.10', '7.7.1908', '8']
     },
     'oracle' => {
-      'versions' => ['6.8', '7.2']
+      'versions' => ['6.10', '7.6']
     }
   }
 end

--- a/spec/unit/recipes/user_ssh_spec.rb
+++ b/spec/unit/recipes/user_ssh_spec.rb
@@ -63,6 +63,7 @@ describe 'system_core::user_ssh' do
         before do
           # Don't use allow_any_instance_of because :home is a static / class scoped method and not an instance method.
           allow(Dir).to receive(:home).with('root').and_return('/root')
+          allow_any_instance_of(Chef::Recipe).to receive(:ssh_authorize_key)
         end
 
         let(:chef_run) do
@@ -74,7 +75,6 @@ describe 'system_core::user_ssh' do
           runner.node.override['system_core']['aws']['profiles']['default']['secret_key'] = 'thisismyreallylongawssectaccesskey'
 
           runner.node.default['system_core']['ssh']['authorized_keys']['root@mydomain.com']['public_key'] = 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDJlvaL0I0HWNE/RblFscFWhjXDwX6UaMBLtG5YdbHHSc1QQO+W+kV15q3T7WnED6In+aK423OzMTk/0/UZrchlxa2KCRNSnRrqViTZZ1XUXwEXqCnBQ9O1El93AAaE73suB9kYfeO105D5AgTTmf41HDc4YAxZtoAOt2KdI2GF7+7IfheI54aWSldmQesfqNloY+ivYIOhyEIwXuO9RS2BEbrFoxuVfOcz62AGcFz07EsALWGNzr4ngT6pe8vCbV5s/f0cDk5z9XZ4Wk2uQI7NQuLkSOmokU3QqZhOYJUjjTdq8VrjARWdF7K5N0/LQ/Wyx6Tgy+XRavnmj/SMhaKd' # rubocop:disable Metrics/LineLength
-
           runner.node.default['system_core']['ssh']['authorized_keys']['root@mydomain.com']['user'] = 'root'
 
           runner.node.default['system_core']['ssh']['user_config']['root']['keys']['id_rsa-chef-solo']['owner'] = 'root'

--- a/test/integration/base/inspec/controls/linux-baseline.rb
+++ b/test/integration/base/inspec/controls/linux-baseline.rb
@@ -2,6 +2,7 @@
 
 include_controls 'system-baseline' do
   skip_control 'papertrail' # not included in base tests
+  skip_control 'hostname' # no hostname is set in the base tests
 end
 
 # rubocop:enable Naming/FileName


### PR DESCRIPTION
### Description

- Justin Spies - (breaking) upgrade default Ruby version from 2.2.2 to 2.6.5
- Justin Spies - (breaking) upgrade apt to 7.2.0 from 6.0, iptables to 6.0.0 from 4.2.0
- Justin Spies - (feature) upgrade numerous dependencies to newest feature release (see metadata.rb for details)
- Justin Spies - (feature) add UEK5 repo URL
- Justin Spies - (feature) increment all OS versions; add Ubuntu 18.04 and CentOS 8 to platform list

### Issues Resolved

- Justin Spies - (fix) do not test hostname in the base tests - Vagrant / VirtualBox defaults to no domain name
- Justin Spies - (fix) defect that was breaking ssh_authorized_keys unit tests

### Check List

- [X] All tests pass. See <https://github.com/eyespies/system_core/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
